### PR TITLE
ZNSERVER first implementation

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Run Clock Pulse Service",
+			"type": "shell",
+			"command": "dotnet run --project Service/Service.csproj",
+			"group": "test",
+			"isBackground": true,
+			"problemMatcher": []
+		}
+	]
+}

--- a/Service.Tests/Service.Tests.csproj
+++ b/Service.Tests/Service.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">

--- a/Service.Tests/ZNServerSinkTests.cs
+++ b/Service.Tests/ZNServerSinkTests.cs
@@ -1,0 +1,197 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
+using System.Net.Sockets;
+using Moq;
+using Tellurian.Trains.ClockPulseApp.Service.Sinks;
+
+namespace Tellurian.Trains.ClockPulseApp.Service.Tests;
+
+[TestClass]
+public class ZNServerSinkTests
+{
+    private const int TEST_PORT = 57111;
+    private const int RECEIVE_TIMEOUT_MS = 5000; // 5 second timeout for receives
+    private readonly Mock<ILogger> _loggerMock;
+    private readonly ZNServerSettings _settings;
+    private readonly CancellationTokenSource _cts;
+
+    public ZNServerSinkTests()
+    {
+        _loggerMock = new Mock<ILogger>();
+        _settings = new ZNServerSettings
+        {
+            Disabled = false,
+            DiscoveryIPAddress = "127.0.0.1", // Use localhost for testing
+            DiscoveryPort = TEST_PORT,
+            StationCode = "TST",
+            StationName = "Test Station"
+        };
+        _cts = new CancellationTokenSource();
+    }
+
+    private async Task<UdpReceiveResult?> ReceiveWithTimeout(UdpClient client, int timeoutMs = RECEIVE_TIMEOUT_MS)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(timeoutMs);
+            return await client.ReceiveAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+    }
+
+    [TestMethod]
+    public async Task SendsDiscoveryMessage_OnInitialization()
+    {
+        // Arrange
+        using var localSocket = new UdpClient(new IPEndPoint(IPAddress.Loopback, TEST_PORT));
+        using var sink = new ZNServerSink(_settings, _loggerMock.Object);
+
+        // Act
+        var initTask = sink.InitializeAsync(new TimeOnly(6, 0));
+        
+        // Assert: Wait for and verify discovery message
+        var result = await ReceiveWithTimeout(localSocket);
+        Assert.IsNotNull(result, "No discovery message received within timeout");
+        var message = System.Text.Encoding.UTF8.GetString(result.Value.Buffer);
+        Assert.AreEqual("ZNSERVER?", message);
+
+        // Cleanup - send response to allow init to complete
+        var responseMsg = System.Text.Encoding.UTF8.GetBytes("ZNSERVERPORT:57112");
+        await localSocket.SendAsync(responseMsg, responseMsg.Length, result.Value.RemoteEndPoint);
+        await Task.WhenAny(initTask, Task.Delay(RECEIVE_TIMEOUT_MS));
+    }
+
+    [TestMethod]
+    public async Task SendsIdMessage_AfterDiscovery()
+    {
+        // Arrange
+        var serverPort = 57112;
+        using var discoverySocket = new UdpClient(new IPEndPoint(IPAddress.Loopback, TEST_PORT));
+        using var responseSocket = new UdpClient(new IPEndPoint(IPAddress.Loopback, serverPort));
+        using var sink = new ZNServerSink(_settings, _loggerMock.Object);
+
+        // Act
+        var initTask = sink.InitializeAsync(new TimeOnly(6, 0));
+
+        // Handle discovery request
+        var discoveryMsg = await ReceiveWithTimeout(discoverySocket);
+        Assert.IsNotNull(discoveryMsg, "No discovery message received within timeout");
+        var portResponse = System.Text.Encoding.UTF8.GetBytes($"ZNSERVERPORT:{serverPort}");
+        await discoverySocket.SendAsync(portResponse, portResponse.Length, discoveryMsg.Value.RemoteEndPoint);
+
+        // Assert: Verify ID message
+        var idMsg = await ReceiveWithTimeout(responseSocket);
+        Assert.IsNotNull(idMsg, "No ID message received within timeout");
+        var idMsgText = System.Text.Encoding.UTF8.GetString(idMsg.Value.Buffer);
+        Assert.AreEqual($"ID:{_settings.StationCode},{_settings.StationName}\r\n", idMsgText);
+
+        await Task.WhenAny(initTask, Task.Delay(RECEIVE_TIMEOUT_MS));
+    }
+
+    [TestMethod]
+    public async Task SendsTimeUpdates_OnPulse()
+    {
+        // Arrange
+        var serverPort = 57112;
+        using var discoverySocket = new UdpClient(new IPEndPoint(IPAddress.Loopback, TEST_PORT));
+        using var responseSocket = new UdpClient(new IPEndPoint(IPAddress.Loopback, serverPort));
+        using var sink = new ZNServerSink(_settings, _loggerMock.Object);
+
+        // Setup connection
+        var initTask = sink.InitializeAsync(new TimeOnly(6, 0));
+        var discoveryMsg = await ReceiveWithTimeout(discoverySocket);
+        Assert.IsNotNull(discoveryMsg, "No discovery message received within timeout");
+        var portResponse = System.Text.Encoding.UTF8.GetBytes($"ZNSERVERPORT:{serverPort}");
+        await discoverySocket.SendAsync(portResponse, portResponse.Length, discoveryMsg.Value.RemoteEndPoint);
+        await ReceiveWithTimeout(responseSocket); // Skip ID message
+        await Task.WhenAny(initTask, Task.Delay(RECEIVE_TIMEOUT_MS));
+
+        // Act
+        await sink.PositiveVoltageAsync();
+
+        // Assert
+        var timeMsg = await ReceiveWithTimeout(responseSocket);
+        Assert.IsNotNull(timeMsg, "No time update message received within timeout");
+        var timeUpdate = System.Text.Encoding.UTF8.GetString(timeMsg.Value.Buffer);
+        StringAssert.StartsWith(timeUpdate, "UHR:");
+        Assert.IsTrue(System.Text.RegularExpressions.Regex.IsMatch(timeUpdate, @"UHR:\d{2}:\d{2}"));
+    }
+
+    [TestMethod]
+    public async Task HandlesDiscoveryTimeout_Gracefully()
+    {
+        // Arrange
+        using var sink = new ZNServerSink(_settings, _loggerMock.Object);
+
+        // Act
+        var initTask = sink.InitializeAsync(new TimeOnly(6, 0));
+
+        // Assert - wait for timeout
+        await Task.Delay(RECEIVE_TIMEOUT_MS);
+        _loggerMock.Verify(l => l.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("No ZNServer response received within timeout")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+        ), Times.AtLeastOnce);
+    }
+
+    [TestMethod]
+    public async Task HandlesInvalidPortResponse_Gracefully()
+    {
+        // Arrange
+        using var discoverySocket = new UdpClient(new IPEndPoint(IPAddress.Loopback, TEST_PORT));
+        using var sink = new ZNServerSink(_settings, _loggerMock.Object);
+
+        // Act
+        var initTask = sink.InitializeAsync(new TimeOnly(6, 0));
+        var discoveryMsg = await ReceiveWithTimeout(discoverySocket);
+        Assert.IsNotNull(discoveryMsg, "No discovery message received within timeout");
+
+        // Send invalid port response
+        var invalidResponse = System.Text.Encoding.UTF8.GetBytes("ZNSERVERPORT:invalid");
+        await discoverySocket.SendAsync(invalidResponse, invalidResponse.Length, discoveryMsg.Value.RemoteEndPoint);
+        
+        // Assert: Should retry discovery
+        discoveryMsg = await ReceiveWithTimeout(discoverySocket);
+        Assert.IsNotNull(discoveryMsg, "No retry discovery message received within timeout");
+        var message = System.Text.Encoding.UTF8.GetString(discoveryMsg.Value.Buffer);
+        Assert.AreEqual("ZNSERVER?", message);
+    }
+
+    [TestMethod]
+    public async Task DisabledSink_DoesNotInitiateDiscovery()
+    {
+        // Arrange
+        var disabledSettings = new ZNServerSettings
+        {
+            Disabled = true,
+            DiscoveryIPAddress = "127.0.0.1",
+            DiscoveryPort = TEST_PORT,
+            StationCode = "TST",
+            StationName = "Test Station"
+        };
+
+        using var discoverySocket = new UdpClient(new IPEndPoint(IPAddress.Loopback, TEST_PORT));
+        using var sink = new ZNServerSink(disabledSettings, _loggerMock.Object);
+
+        // Act
+        await sink.InitializeAsync(new TimeOnly(6, 0));
+
+        // Assert - should not receive any discovery message
+        var result = await ReceiveWithTimeout(discoverySocket, 1000);
+        Assert.IsNull(result, "Disabled sink should not send discovery messages");
+    }
+
+    [TestCleanup]
+    public void CleanupTest()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+}

--- a/Service/PulseGeneratorSettings.cs
+++ b/Service/PulseGeneratorSettings.cs
@@ -23,6 +23,7 @@ public sealed class PulseGeneratorSettings
     public UdpBroadcastSettings UdpBroadcast { get; set; } = new();
     public SerialPulseSinkSettings SerialPulseSink { get; init; } = new();
     public RpiRelayBoardPulseSinkSettings RpiRelayBoardPulseSink { get; init; } = new();
+    public ZNServerSettings ZNServer { get; init; } = new();
     public override string ToString()
     {
         var text = new StringBuilder(200);
@@ -58,6 +59,17 @@ public sealed class RpiRelayBoardPulseSinkSettings
     public bool Disabled { get; set; } = true;
     public string ClockStoppedPinUse { get; set; } = Sinks.ClockStoppedPinUse.RedGreen.ToString();
     public override string ToString() => "RPI Relay Board: no specific setting";
+}
+
+public sealed class ZNServerSettings
+{
+    public bool Disabled { get; set; } = true;
+    public string DiscoveryIPAddress { get; set; } = "255.255.255.255";
+    public int DiscoveryPort { get; set; } = 57111;
+    public string StationCode { get; set; } = "HBF"; // 3-letter station code
+    public string StationName { get; set; } = "Hauptbahnhof"; // Full station name
+
+    public override string ToString() => $"ZNServer Discovery: {DiscoveryIPAddress}:{DiscoveryPort}, Station: {StationCode}";
 }
 
 

--- a/Service/Scripts/deploy.sh
+++ b/Service/Scripts/deploy.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Help function
+show_usage() {
+    echo "Usage: $0 [-d <install_dir>] [-i] [-u <user>]"
+    echo "Options:"
+    echo "  -d  Installation directory (default: /opt/clockpulse)"
+    echo "  -i  Install as system service"
+    echo "  -u  User to run service as (default: current user)"
+    exit 1
+}
+
+# Parse command line arguments
+INSTALL_DIR="/opt/clockpulse"  # Default value
+INSTALL_SERVICE=false
+SERVICE_USER=$(whoami)  # Default to current user
+
+while getopts "d:iu:" opt; do
+    case $opt in
+        d) INSTALL_DIR="$OPTARG" ;;
+        i) INSTALL_SERVICE=true ;;
+        u) SERVICE_USER="$OPTARG" ;;
+        ?) show_usage ;;
+    esac
+done
+
+# Get script location
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Create installation directory and set permissions
+echo "Setting up installation directory..."
+sudo mkdir -p "$INSTALL_DIR"
+sudo chown "$SERVICE_USER:$SERVICE_USER" "$INSTALL_DIR"
+
+# Copy files
+echo "Copying application files..."
+sudo cp "$SCRIPT_DIR/Tellurian.Trains.ClockPulseApp.Service" "$SCRIPT_DIR/appsettings.json" "$INSTALL_DIR/"
+
+# Set execute permissions
+echo "Setting permissions..."
+sudo chmod +x "$INSTALL_DIR/Tellurian.Trains.ClockPulseApp.Service"
+
+if [ "$INSTALL_SERVICE" = true ]; then
+    # Create systemd service file
+    echo "Creating systemd service..."
+    sudo tee /etc/systemd/system/clockpulse.service << EOF
+[Unit]
+Description=Clock Pulse Service
+After=network.target
+
+[Service]
+Type=simple
+User=$SERVICE_USER
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$INSTALL_DIR/Tellurian.Trains.ClockPulseApp.Service
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    # Reload systemd and enable service
+    echo "Configuring service..."
+    sudo systemctl daemon-reload
+    sudo systemctl enable clockpulse.service
+
+    echo "Installation complete!"
+    echo "Service management commands:"
+    echo "  Start:  sudo systemctl start clockpulse.service"
+    echo "  Stop:   sudo systemctl stop clockpulse.service"
+    echo "  Status: sudo systemctl status clockpulse.service"
+    echo "  Logs:   sudo journalctl -u clockpulse.service -f"
+else
+    echo "Installation complete!"
+    echo "To run the service manually:"
+    echo "  cd $INSTALL_DIR"
+    echo "  ./Tellurian.Trains.ClockPulseApp.Service"
+fi

--- a/Service/Service.csproj
+++ b/Service/Service.csproj
@@ -18,6 +18,13 @@
 		<None Remove="AnalogueTime.txt" />
 	</ItemGroup>
 	<ItemGroup>
+		<Content Include="Scripts\deploy.sh">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			<Link>deploy.sh</Link>
+		</Content>
+	</ItemGroup>
+	<ItemGroup>
 		<_WebToolingArtifacts Remove="Properties\PublishProfiles\linux-arm-32.pubxml" />
 		<_WebToolingArtifacts Remove="Properties\PublishProfiles\linux-arm-64.pubxml" />
 		<_WebToolingArtifacts Remove="Properties\PublishProfiles\win-arm64.pubxml" />
@@ -25,8 +32,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Device.Gpio" Version="3.2.0" />
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
-		<PackageReference Include="Tellurian.Trains.MeetingApp.Contracts" Version="3.6.2" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+		<PackageReference Include="Tellurian.Trains.MeetingApp.Contracts" Version="3.7.1" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
 		<PackageReference Include="System.IO.Ports" Version="8.0.0" />
 	</ItemGroup>

--- a/Service/Sinks/ZNServerSink.cs
+++ b/Service/Sinks/ZNServerSink.cs
@@ -1,0 +1,196 @@
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+using Tellurian.Trains.MeetingApp.Contracts;
+
+namespace Tellurian.Trains.ClockPulseApp.Service.Sinks;
+
+public sealed class ZNServerSink : IPulseSink, IControlSink, IStatusSink, IDisposable
+{
+    private readonly ILogger Logger;
+    private readonly UdpClient BroadcastClient;
+    private readonly ZNServerSettings Settings;
+    private IPEndPoint? ZNServerEndPoint;
+    private bool IsDisposed;
+    private DateTimeOffset lastMessageTime;
+    private const int CONNECTION_TIMEOUT_MINUTES = 5;
+    private Timer? connectionMonitorTimer;
+
+    public ZNServerSink(ZNServerSettings settings, ILogger logger)
+    {
+        Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        BroadcastClient = new UdpClient()
+        {
+            EnableBroadcast = true
+        };
+    }
+
+    private async Task SendIdMessage()
+    {
+        if (IsDisposed || ZNServerEndPoint == null) return;
+        var message = System.Text.Encoding.UTF8.GetBytes($"ID:{Settings.StationCode},{Settings.StationName}\r\n");
+        await BroadcastClient.SendAsync(message, message.Length, ZNServerEndPoint);
+        UpdateLastMessageTime();
+        Logger.LogDebug("ZNServer: ID message sent for station {code} ({name})", Settings.StationCode, Settings.StationName);
+    }
+
+    private async Task DiscoverZNServer()
+    {
+        try
+        {
+            var discoveryMessage = "ZNSERVER?"u8.ToArray();
+            var broadcastEndpoint = new IPEndPoint(IPAddress.Parse(Settings.DiscoveryIPAddress), Settings.DiscoveryPort);
+            await BroadcastClient.SendAsync(discoveryMessage, discoveryMessage.Length, broadcastEndpoint);
+
+            var receiveTask = BroadcastClient.ReceiveAsync();
+            if (await Task.WhenAny(receiveTask, Task.Delay(5000)) == receiveTask)
+            {
+                var result = await receiveTask;
+                var response = System.Text.Encoding.UTF8.GetString(result.Buffer);
+                if (response.StartsWith("ZNSERVERPORT:"))
+                {
+                    var portStr = response.Substring("ZNSERVERPORT:".Length);
+                    if (int.TryParse(portStr, out var port))
+                    {
+                        ZNServerEndPoint = new IPEndPoint(result.RemoteEndPoint.Address, port);
+                        Logger.LogInformation("ZNServer discovered at {address}:{port}", 
+                            ZNServerEndPoint.Address, ZNServerEndPoint.Port);
+                        await SendIdMessage();
+                    }
+                }
+            }
+            else
+            {
+                Logger.LogWarning("No ZNServer response received within timeout");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error during ZNServer discovery");
+        }
+    }
+
+    private void StartConnectionMonitoring()
+    {
+        lastMessageTime = DateTimeOffset.UtcNow;
+        connectionMonitorTimer?.Dispose();
+        connectionMonitorTimer = new Timer(CheckConnection, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+    }
+
+    private async void CheckConnection(object? state)
+    {
+        if (IsDisposed) return;
+
+        var timeSinceLastMessage = DateTimeOffset.UtcNow - lastMessageTime;
+        if (timeSinceLastMessage.TotalMinutes >= CONNECTION_TIMEOUT_MINUTES)
+        {
+            Logger.LogWarning("No messages from ZNServer for {minutes} minutes, attempting rediscovery", CONNECTION_TIMEOUT_MINUTES);
+            await ReconnectToServer();
+        }
+    }
+
+    private async Task ReconnectToServer()
+    {
+        ZNServerEndPoint = null;
+        await DiscoverZNServer();
+        if (ZNServerEndPoint != null && lastTime.HasValue)
+        {
+            await SendTimeUpdate(lastTime.Value.ToString("HH:mm"));
+        }
+    }
+
+    private void UpdateLastMessageTime()
+    {
+        lastMessageTime = DateTimeOffset.UtcNow;
+    }
+
+    private async Task SendTimeUpdate(string time)
+    {
+        if (IsDisposed || ZNServerEndPoint == null) return;
+        try
+        {
+            var message = System.Text.Encoding.UTF8.GetBytes($"UHR:{time}");
+            await BroadcastClient.SendAsync(message, message.Length, ZNServerEndPoint);
+            UpdateLastMessageTime();
+            Logger.LogDebug("ZNServer: Time update sent {time}", time);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to send time update to ZNServer");
+            await ReconnectToServer();
+        }
+    }
+
+    public async Task InitializeAsync(TimeOnly analogueStartTime)
+    {
+        Logger.LogInformation("ZNServer sink initializing at {time}", analogueStartTime);
+        await DiscoverZNServer();
+        if (ZNServerEndPoint != null)
+        {
+            await SendTimeUpdate(analogueStartTime.ToString("HH:mm"));
+            lastTime = analogueStartTime;
+            StartConnectionMonitoring();
+        }
+    }
+
+    public Task CleanupAsync()
+    {
+        connectionMonitorTimer?.Dispose();
+        Logger.LogInformation("ZNServer sink cleaned up");
+        return Task.CompletedTask;
+    }
+
+    private TimeOnly? lastTime;
+
+    public async Task NegativeVoltageAsync()
+    {
+        if (lastTime.HasValue)
+        {
+            var nextTime = lastTime.Value.AddMinutes(1);
+            await SendTimeUpdate(nextTime.ToString("HH:mm"));
+            lastTime = nextTime;
+        }
+    }
+
+    public async Task PositiveVoltageAsync()
+    {
+        if (lastTime.HasValue)
+        {
+            var nextTime = lastTime.Value.AddMinutes(1);
+            await SendTimeUpdate(nextTime.ToString("HH:mm"));
+            lastTime = nextTime;
+        }
+    }
+
+    public Task ZeroVoltageAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task ClockIsStartedAsync()
+    {
+        Logger.LogDebug("ZNServer: Clock started");
+        return Task.CompletedTask;
+    }
+
+    public Task ClockIsStoppedAsync()
+    {
+        Logger.LogDebug("ZNServer: Clock stopped");
+        return Task.CompletedTask;
+    }
+
+    public Task SessionIsCompletedAsync()
+    {
+        Logger.LogDebug("ZNServer: Session completed");
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        if (IsDisposed) return;
+        connectionMonitorTimer?.Dispose();
+        BroadcastClient.Dispose();
+        IsDisposed = true;
+    }
+}

--- a/Service/Sinks/ZNServerSink.cs
+++ b/Service/Sinks/ZNServerSink.cs
@@ -47,10 +47,10 @@ public sealed class ZNServerSink : IPulseSink, IControlSink, IStatusSink, IDispo
             if (await Task.WhenAny(receiveTask, Task.Delay(5000)) == receiveTask)
             {
                 var result = await receiveTask;
-                var response = System.Text.Encoding.UTF8.GetString(result.Buffer);
-                if (response.StartsWith("ZNSERVERPORT:"))
+                var ZNresponse = System.Text.Encoding.UTF8.GetString(result.Buffer);
+                if (ZNresponse.StartsWith("ZNSERVERPORT:"))
                 {
-                    var portStr = response.Substring("ZNSERVERPORT:".Length);
+                    var portStr = ZNresponse.Substring("ZNSERVERPORT:".Length);
                     if (int.TryParse(portStr, out var port))
                     {
                         ZNServerEndPoint = new IPEndPoint(result.RemoteEndPoint.Address, port);

--- a/Service/Worker.cs
+++ b/Service/Worker.cs
@@ -50,6 +50,10 @@ public class Worker : BackgroundService
         {
             sinks.Add(new RpiRelayBoardSink(new GpioController(), Enum.Parse<ClockStoppedPinUse>(settings.RpiRelayBoardPulseSink.ClockStoppedPinUse), logger));
         }
+        if (!settings.ZNServer.Disabled)
+        {
+            sinks.Add(new ZNServerSink(settings.ZNServer, logger));
+        }
         PulseGenerator = new PulseGenerator(settings, sinks, Logger, ResetOnStart, AnalogueClockStartTime);
         Timer = new PeriodicTimer(TimeSpan.FromSeconds(PulseGenerator.PollIntervalSeconds));
     }

--- a/Service/appsettings.json
+++ b/Service/appsettings.json
@@ -30,6 +30,13 @@
       "PortNumber": 25501,
       "Disabled": true
     },
+    "ZNServer": {
+      "DiscoveryIPAddress": "255.255.255.255",
+      "DiscoveryPort": 57111,
+      "StationCode": "FKB",  // 3-letter station code
+      "StationName": "Falkenberg",  // Full station name
+      "Disabled": true
+    },
     "SerialPulseSink": {
       "PortName": "COM3",
       "DtrOnly": false,

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Local" value="/Users/dirkjankaper/Documents/code/NugetPackages" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Clock Pulse Service - ZNSERVER Integration
Features Added
1. ZNSERVER Communication 

- Automatic server discovery via UDP broadcast (port 57111) 
- Station identity management with configurable station code and name 
- Time synchronization using the UHR command format
- Connection health monitoring with 5-minute timeout Automatic reconnection and state recovery

2. Linux ARM64 Deployment Self-contained application package

- Systemd service installation script
- Configurable installation options:
- Custom installation directory
- Service user selection
- Automatic startup configuration
- Protocol Specification
- Message Flow
- Discovery Phase

Client broadcasts discovery request
Server responds with port number
Client establishes connection
Station Registration

Sends station ID after connection
Format: 3-letter code + station name
Example: Hauptbahnhof (HBF)

3. Time Updates

- Regular time updates in HH:mm format
- Automatic resync after reconnection
- Maintains time state during disconnections
- Configuration
- Add station details in appsettings.json
- Default port: 57111
- Configurable timeout (default: 5 minutes)

4. Optional systemd integration

Usage
> ./deploy.sh [-d <dir>] [-i] [-u <user>]